### PR TITLE
Support arrays in transformer

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -179,7 +179,7 @@ export class Connection extends Builder<Query> {
       .then((result) => {
         session.close();
         // TODO transformer needs to accept a type parameter
-        return this.transformer.transformResult(result) as any;
+        return this.transformer.transformRecords(result.records) as any;
       })
       .catch((error) => {
         session.close();

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,9 +1,9 @@
 import { Connection } from './connection';
-import { SanitizedRecord, SanitizedValue } from './transformer';
 import { Builder } from './builder';
 import { ClauseCollection } from './clause-collection';
 import { Clause } from './clause';
 import { Observable } from 'rxjs';
+import { Dictionary } from 'lodash';
 
 export class Query extends Builder<Query> {
   protected clauses = new ClauseCollection();
@@ -64,14 +64,14 @@ export class Query extends Builder<Query> {
    * ES2015/ES6: `results.map(record => record.friends)`.
    *
    * If you use typescript you can use the type parameter to hint at the type of
-   * the return value which is essentially `Dictionary<R>[]`.
+   * the return value which is `Dictionary<R>[]`.
    *
    * Throws an exception if this query does not have a connection or has no
    * clauses.
    *
-   * @returns {Promise<SanitizedRecord<R>[]>}
+   * @returns {Promise<Dictionary<R>[]>}
    */
-  async run<R = SanitizedValue>(): Promise<SanitizedRecord<R>[]> {
+  async run<R = any>(): Promise<Dictionary<R>[]> {
     if (!this.connection) {
       throw Error('Cannot run query; no connection object available.');
     }
@@ -120,12 +120,12 @@ export class Query extends Builder<Query> {
    * ```
    *
    * If you use typescript you can use the type parameter to hint at the type of
-   * the return value which is essentially `Dictionary<R>`.
+   * the return value which is `Observable<Dictionary<R>>`.
    *
    * Throws an exception if this query does not have a connection or has no
    * clauses.
    */
-  stream<R = SanitizedValue>(): Observable<SanitizedRecord<R>> {
+  stream<R = any>(): Observable<Dictionary<R>> {
     if (!this.connection) {
       throw Error('Cannot run query; no connection object available.');
     }
@@ -134,7 +134,7 @@ export class Query extends Builder<Query> {
   }
 
   /**
-   * * Runs the current query on its connection and returns the first result.
+   * Runs the current query on its connection and returns the first result.
    * If the query was created by calling a chainable method of a connection,
    * the query's connection was automatically set.
    *
@@ -143,8 +143,12 @@ export class Query extends Builder<Query> {
    * Returns a promise that resolves to a single record. Each key of the
    * record is the name of a variable that you specified in your `RETURN`
    * clause.
+   *
+   * If you use typescript you can use the type parameter to hint at the type of
+   * the return value which is `Dictionary<R>`. Note that this function returns
+   * `undefined` if the result set was empty.
    */
-  async first<R = SanitizedValue>(): Promise<SanitizedRecord<R>> {
+  async first<R = any>(): Promise<Dictionary<R>> {
     return this.run<R>().then(results => results && results.length > 0 ? results[0] : undefined);
   }
 
@@ -184,8 +188,6 @@ export class Query extends Builder<Query> {
   /**
    * Returns an object that includes both the query and the params ready to be
    * passed to the neo4j driver.
-   *
-   * @returns {{query: string; params: _.Dictionary<any>}}
    */
   buildQueryObject() {
     return this.clauses.buildQueryObject();

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,10 +1,10 @@
 import { v1 as neo4j } from 'neo4j-driver';
 import { Dictionary, map, mapValues } from 'lodash';
 import { Dictionary, map, mapValues, isArray } from 'lodash';
-import record from 'neo4j-driver/types/v1/record';
-import integer from 'neo4j-driver/types/v1/integer';
+import Record from 'neo4j-driver/types/v1/record';
+import Integer from 'neo4j-driver/types/v1/integer';
 
-export type NeoInteger = integer | { low: number, high: number };
+export type NeoInteger = Integer | { low: number, high: number };
 export type NeoValue = string | boolean | null | number | NeoInteger;
 export interface NeoNode {
   identity: NeoInteger;
@@ -37,11 +37,11 @@ export type SanitizedRecord<T = SanitizedValue> = Dictionary<T>;
 
 
 export class Transformer {
-  transformResult(result: { records: record[] }): SanitizedRecord[] {
+  transformResult(result: { records: Record[] }): SanitizedRecord[] {
     return map(result.records, rec => this.transformRecord(rec));
   }
 
-  transformRecord(record: record): SanitizedRecord {
+  transformRecord(record: Record): SanitizedRecord {
     const recordObj = record.toObject() as Dictionary<NeoValue>;
     return mapValues(recordObj, node => this.transformValue(node));
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,5 +1,6 @@
 import { v1 as neo4j } from 'neo4j-driver';
 import { Dictionary, map, mapValues } from 'lodash';
+import { Dictionary, map, mapValues, isArray } from 'lodash';
 import record from 'neo4j-driver/types/v1/record';
 import integer from 'neo4j-driver/types/v1/integer';
 
@@ -53,6 +54,9 @@ export class Transformer {
       || typeof value === 'number'
     ) {
       return value as SanitizedValue;
+    }
+    if (isArray(value)) {
+      return map(value, this.transformValue.bind(this)) as any;
     }
     if (neo4j.isInt(value)) {
       return this.convertInteger(value as NeoInteger);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -67,6 +67,9 @@ export class Transformer {
     if (this.isRelation(value)) {
       return this.transformRelation(value as any);
     }
+    if (typeof value === 'object') {
+      return mapValues(value, this.transformValue.bind(this));
+    }
     return null;
   }
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,7 +1,6 @@
 import { v1 as neo4j } from 'neo4j-driver';
 import { Dictionary, map, mapValues, isArray } from 'lodash';
-import Record from 'neo4j-driver/types/v1/record';
-import Integer from 'neo4j-driver/types/v1/integer';
+import { Record, Integer } from 'neo4j-driver/types/v1';
 
 export type NeoValue = string | boolean | null | number | Integer;
 export interface NeoNode {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -81,7 +81,7 @@ export class Transformer {
     return {
       identity: neo4j.integer.toString(node.identity),
       labels: node.labels,
-      properties: this.convertNumbers(node.properties),
+      properties: mapValues(node.properties, this.transformValue.bind(this)),
     };
   }
 
@@ -95,23 +95,23 @@ export class Transformer {
       start: neo4j.integer.toString(rel.start),
       end: neo4j.integer.toString(rel.end),
       label: rel.type,
-      properties: this.convertNumbers(rel.properties),
+      properties: mapValues(rel.properties, this.transformValue.bind(this)),
     };
   }
 
-  convertNumbers(object: Dictionary<NeoValue>): Dictionary<PlainValue> {
-    return mapValues(object, (value: NeoValue): PlainValue => {
-      if (
-        value === null
-        || typeof value === 'string'
-        || typeof value === 'boolean'
-        || typeof value === 'number'
-      ) {
-        return value as PlainValue;
-      }
-      return this.convertInteger(value);
-    });
-  }
+  // convertNumbers(object: Dictionary<NeoValue>): Dictionary<PlainValue> {
+  //   return mapValues(object, (value: NeoValue): PlainValue => {
+  //     if (
+  //       value === null
+  //       || typeof value === 'string'
+  //       || typeof value === 'boolean'
+  //       || typeof value === 'number'
+  //     ) {
+  //       return value as PlainValue;
+  //     }
+  //     return this.convertInteger(value);
+  //   });
+  // }
 
   convertInteger(num: NeoInteger) {
     if (neo4j.integer.inSafeRange(num)) {

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -7,13 +7,7 @@ import { each, Dictionary } from 'lodash';
 import { Observable } from 'rxjs';
 import { AuthToken, Config } from 'neo4j-driver/types/v1/driver';
 import { Driver } from 'neo4j-driver/types/v1';
-
-
-const neo4jUrl: string = process.env.NEO4J_URL;
-const neo4jCredentials: Credentials = {
-  username: process.env.NEO4J_USER,
-  password: process.env.NEO4J_PASS,
-};
+import { neo4jCredentials, neo4jUrl, waitForNeo } from './utils';
 
 describe('Connection', () => {
   let connection: Connection;
@@ -42,23 +36,7 @@ describe('Connection', () => {
   }
 
   // Wait for neo4j to be ready before testing
-  before(async function () {
-    this.timeout(40000);
-    let attempts = 0;
-    const connection = new Connection(neo4jUrl, neo4jCredentials);
-    while (attempts < 20) {
-      // Wait a short time before trying again
-      if (attempts > 0) await new Promise(res => setTimeout(res, 100));
-
-      try {
-        // Attempt a query and exit the loop if it succeeds
-        attempts += 1;
-        await connection.query().return('1').run();
-        break;
-      } catch {}
-    }
-    connection.close();
-  });
+  before(waitForNeo);
 
   beforeEach(() => {
     connection = new Connection(neo4jUrl, neo4jCredentials, driverConstructor);

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -166,7 +166,7 @@ describe('Connection', () => {
 
       let count = 0;
       return observable
-        .do(row => {
+        .do((row) => {
           expect(row.n.properties).to.deep.equal(records[count]);
           expect(row.n.labels).to.deep.equal(['TestStreamRecord']);
           count += 1;

--- a/tests/scenarios.test.ts
+++ b/tests/scenarios.test.ts
@@ -1,0 +1,232 @@
+import { neo4jCredentials, neo4jUrl, waitForNeo } from './utils';
+import { Connection } from '../src';
+import { expect } from '../test-setup';
+import { Dictionary, isNil } from 'lodash';
+import { node, relation } from '../src/clauses';
+
+function expectResults(results, length?: number | null, properties?: string[] | null, cb?: null | ((row: any) => any)) {
+  expect(results).to.be.an.instanceOf(Array);
+
+  if (!isNil(length)) {
+    expect(results).to.have.lengthOf(length);
+  }
+
+  results.forEach(row => {
+    expect(row).to.be.an.instanceOf(Object);
+
+    if (!isNil(properties)) {
+      expect(row).to.have.own.keys(properties);
+    }
+
+    if (!isNil(cb)) {
+      cb(row);
+    }
+  });
+}
+
+function expectNode(record: any, labels?: string[], properties?: Dictionary<any>) {
+  expect(record).to.be.an.instanceOf(Object)
+    .and.to.have.keys([ 'identity', 'properties', 'labels']);
+
+  expect(record.identity).to.be.a('string')
+    .and.to.match(/[0-9]+/);
+
+  expect(record.labels).to.be.an.instanceOf(Array);
+  record.labels.forEach(label => expect(label).to.be.a('string'));
+  if (labels) {
+    expect(record.labels).to.have.members(labels);
+  }
+
+  expect(record.properties).to.be.an('object');
+  if (properties) {
+    expect(record.properties).to.eql(properties);
+  }
+}
+
+function expectRelation(relation: any, label?: string, properties?: Dictionary<any>) {
+  expect(relation).to.be.an.instanceOf(Object)
+    .and.to.have.keys([ 'identity', 'properties', 'label', 'start', 'end']);
+
+  expect(relation.identity).to.be.a('string')
+    .and.to.match(/[0-9]+/);
+  expect(relation.start).to.be.a('string')
+    .and.to.match(/[0-9]+/);
+  expect(relation.end).to.be.a('string')
+    .and.to.match(/[0-9]+/);
+
+  expect(relation.label).to.be.a('string');
+  if (label) {
+    expect(relation.label).to.equal(label);
+  }
+
+  expect(relation.properties).to.be.an('object');
+  if (properties) {
+    expect(relation.properties).to.eql(properties);
+  }
+}
+
+describe('scenarios', () => {
+  let db: Connection;
+
+  before(waitForNeo);
+  before(() => db = new Connection(neo4jUrl, neo4jCredentials));
+  before(() => db.matchNode('node').delete('node').run());
+  after(() => db.matchNode('node').delete('node').run());
+  after(() => db.close());
+
+  describe('node', () => {
+    it('should create a node', async () => {
+      const results = await db.createNode('person', 'Person', { name: 'Alan', age: 45 })
+        .return('person')
+        .run();
+
+      expectResults(results, 1, ['person'], row => {
+        expectNode(row.person, ['Person'], { name: 'Alan', age: 45 });
+      });
+    });
+
+    it('should create a node without returning anything', async () => {
+      const results = await db.createNode('person', 'Person', { name: 'Steve', age: 42 })
+        .run();
+
+      expectResults(results, 0);
+    });
+
+    it('should fetch multiple nodes', async () => {
+      const results = await db.matchNode('person', 'Person')
+        .return('person')
+        .run();
+
+      expectResults(results, 2, ['person'], row => {
+        expectNode(row.person, ['Person']);
+        expect(row.person.properties).to.have.keys(['name', 'age']);
+      });
+    });
+
+    it('should fetch a property of a set of nodes', async () => {
+      const results = await db.matchNode('person', 'Person')
+        .return({ 'person.age': 'yearsOld' })
+        .run();
+
+      expectResults(results, 2, ['yearsOld'], row => expect(row.yearsOld).to.be.an('number'));
+    });
+
+    it('should return an array property', async () => {
+      const results = await db.createNode('arrNode', 'ArrNode', {
+        values: [1, 2, 3],
+      })
+        .return('arrNode')
+        .run();
+
+      expectResults(results, 1, ['arrNode'], row => {
+        expectNode(row.arrNode, ['ArrNode'], {
+          values: [1, 2, 3],
+        });
+      });
+    });
+
+    it('should return a relationship', async () => {
+      const results = await db.create([
+        node('person', 'Person', { name: 'Alfred', age: 64 }),
+        relation('out', 'hasJob', 'HasJob', { since: 2004 }),
+        node('job', 'Job', { name: 'Butler' })
+      ])
+        .return(['person', 'hasJob', 'job'])
+        .run();
+
+      expectResults(results, 1, ['person', 'hasJob', 'job'], row => {
+        expectNode(row.person, ['Person'], { name: 'Alfred', age: 64 });
+        expectRelation(row.hasJob, 'HasJob', { since: 2004 });
+        expectNode(row.job, ['Job'], { name: 'Butler' });
+      });
+    });
+
+    it.only('should handle an array of nodes and relationships', async () => {
+      // Create relationships
+      await db.create([
+        node(['City'], { name: 'Cityburg' }),
+        relation('out', ['Road'], { length: 10 }),
+        node(['City'], { name: 'Townsville' }),
+        relation('out', ['Road'], { length: 5 }),
+        node(['City'], { name: 'Rural hideout' }),
+        relation('out', ['Road'], { length: 14 }),
+        node(['City'], { name: 'Village' }),
+      ])
+        .run();
+
+      const results = await db.raw('MATCH p = (:City)-[:Road*3]->(:City)')
+        .return({ 'relationships(p)': 'rels', 'nodes(p)': 'nodes' })
+        .run();
+
+      expectResults(results, 1, ['rels', 'nodes'], row => {
+        expect(row.rels).to.be.an.instanceOf(Array)
+          .and.to.have.a.lengthOf(3);
+        row.rels.forEach(rel => {
+          expectRelation(rel, 'Road');
+          expect(rel.properties).to.have.own.keys(['length']);
+        });
+
+        expect(row.nodes).to.be.an.instanceOf(Array)
+          .and.to.have.a.lengthOf(4);
+        row.nodes.forEach(node => {
+          expectNode(node, ['City']);
+          expect(node.properties).to.have.own.keys(['name']);
+        });
+      });
+    });
+  });
+
+  describe('literals', () => {
+    it('should handle value literals', async () => {
+      const results = await db.return([
+        '1 AS numberVal',
+        '"string" AS stringVal',
+        'null AS nullVal',
+        'true AS boolVal',
+      ])
+        .run();
+
+      expectResults(results, 1, null, row => {
+        expect(row).to.have.own.property('numberVal', 1);
+        expect(row).to.have.own.property('stringVal', 'string');
+        expect(row).to.have.own.property('nullVal', null);
+        expect(row).to.have.own.property('boolVal', true);
+      });
+    });
+
+    it('should handle an array literal', async () => {
+      const results = await db.return('range(0, 5)').run();
+
+      expectResults(results, 1, ['range(0, 5)'], row => {
+        expect(row['range(0, 5)']).to.eql([0, 1, 2, 3, 4, 5]);
+      });
+    });
+
+    it('should handle a map literal', async () => {
+      const results = await db.return('{ a: 1, b: true, c: "a string" } as map').run();
+
+      expectResults(results, 1, ['map'], row => {
+        expect(row.map).to.eql({ a: 1, b: true, c: 'a string' });
+      });
+    });
+
+    it('should handle a nested array literal', async () => {
+      const results = await db.return('{ a: [1, 2, 3], b: [4, 5, 6] } as map').run();
+
+      expectResults(results, 1, ['map'], row => {
+        expect(row.map).to.eql({ a: [1, 2, 3], b: [4, 5, 6] });
+      });
+    });
+
+    it('should handle a nested map literal', async () => {
+      const results = await db.return('[{ a: "name", b: true }, { c: 1, d: null }] as arr').run();
+
+      expectResults(results, 1, ['arr'], row => {
+        expect(row.arr).to.eql([
+          { a: 'name', b: true },
+          { c: 1, d: null },
+        ]);
+      });
+    });
+  });
+});

--- a/tests/scenarios.test.ts
+++ b/tests/scenarios.test.ts
@@ -4,14 +4,19 @@ import { expect } from '../test-setup';
 import { Dictionary, isNil } from 'lodash';
 import { node, relation } from '../src/clauses';
 
-function expectResults(results, length?: number | null, properties?: string[] | null, cb?: null | ((row: any) => any)) {
+function expectResults(
+  results: any,
+  length?: number | null,
+  properties?: string[] | null,
+  cb?: null | ((row: any) => any),
+) {
   expect(results).to.be.an.instanceOf(Array);
 
   if (!isNil(length)) {
     expect(results).to.have.lengthOf(length);
   }
 
-  results.forEach(row => {
+  results.forEach((row) => {
     expect(row).to.be.an.instanceOf(Object);
 
     if (!isNil(properties)) {
@@ -26,7 +31,7 @@ function expectResults(results, length?: number | null, properties?: string[] | 
 
 function expectNode(record: any, labels?: string[], properties?: Dictionary<any>) {
   expect(record).to.be.an.instanceOf(Object)
-    .and.to.have.keys([ 'identity', 'properties', 'labels']);
+    .and.to.have.keys(['identity', 'properties', 'labels']);
 
   expect(record.identity).to.be.a('string')
     .and.to.match(/[0-9]+/);
@@ -45,7 +50,7 @@ function expectNode(record: any, labels?: string[], properties?: Dictionary<any>
 
 function expectRelation(relation: any, label?: string, properties?: Dictionary<any>) {
   expect(relation).to.be.an.instanceOf(Object)
-    .and.to.have.keys([ 'identity', 'properties', 'label', 'start', 'end']);
+    .and.to.have.keys(['identity', 'properties', 'label', 'start', 'end']);
 
   expect(relation.identity).to.be.a('string')
     .and.to.match(/[0-9]+/);
@@ -80,7 +85,7 @@ describe('scenarios', () => {
         .return('person')
         .run();
 
-      expectResults(results, 1, ['person'], row => {
+      expectResults(results, 1, ['person'], (row) => {
         expectNode(row.person, ['Person'], { name: 'Alan', age: 45 });
       });
     });
@@ -97,7 +102,7 @@ describe('scenarios', () => {
         .return('person')
         .run();
 
-      expectResults(results, 2, ['person'], row => {
+      expectResults(results, 2, ['person'], (row) => {
         expectNode(row.person, ['Person']);
         expect(row.person.properties).to.have.keys(['name', 'age']);
       });
@@ -118,7 +123,7 @@ describe('scenarios', () => {
         .return('arrNode')
         .run();
 
-      expectResults(results, 1, ['arrNode'], row => {
+      expectResults(results, 1, ['arrNode'], (row) => {
         expectNode(row.arrNode, ['ArrNode'], {
           values: [1, 2, 3],
         });
@@ -129,12 +134,12 @@ describe('scenarios', () => {
       const results = await db.create([
         node('person', 'Person', { name: 'Alfred', age: 64 }),
         relation('out', 'hasJob', 'HasJob', { since: 2004 }),
-        node('job', 'Job', { name: 'Butler' })
+        node('job', 'Job', { name: 'Butler' }),
       ])
         .return(['person', 'hasJob', 'job'])
         .run();
 
-      expectResults(results, 1, ['person', 'hasJob', 'job'], row => {
+      expectResults(results, 1, ['person', 'hasJob', 'job'], (row) => {
         expectNode(row.person, ['Person'], { name: 'Alfred', age: 64 });
         expectRelation(row.hasJob, 'HasJob', { since: 2004 });
         expectNode(row.job, ['Job'], { name: 'Butler' });
@@ -158,17 +163,17 @@ describe('scenarios', () => {
         .return({ 'relationships(p)': 'rels', 'nodes(p)': 'nodes' })
         .run();
 
-      expectResults(results, 1, ['rels', 'nodes'], row => {
+      expectResults(results, 1, ['rels', 'nodes'], (row) => {
         expect(row.rels).to.be.an.instanceOf(Array)
           .and.to.have.a.lengthOf(3);
-        row.rels.forEach(rel => {
+        row.rels.forEach((rel) => {
           expectRelation(rel, 'Road');
           expect(rel.properties).to.have.own.keys(['length']);
         });
 
         expect(row.nodes).to.be.an.instanceOf(Array)
           .and.to.have.a.lengthOf(4);
-        row.nodes.forEach(node => {
+        row.nodes.forEach((node) => {
           expectNode(node, ['City']);
           expect(node.properties).to.have.own.keys(['name']);
         });
@@ -186,7 +191,7 @@ describe('scenarios', () => {
       ])
         .run();
 
-      expectResults(results, 1, null, row => {
+      expectResults(results, 1, null, (row) => {
         expect(row).to.have.own.property('numberVal', 1);
         expect(row).to.have.own.property('stringVal', 'string');
         expect(row).to.have.own.property('nullVal', null);
@@ -197,7 +202,7 @@ describe('scenarios', () => {
     it('should handle an array literal', async () => {
       const results = await db.return('range(0, 5)').run();
 
-      expectResults(results, 1, ['range(0, 5)'], row => {
+      expectResults(results, 1, ['range(0, 5)'], (row) => {
         expect(row['range(0, 5)']).to.eql([0, 1, 2, 3, 4, 5]);
       });
     });
@@ -205,7 +210,7 @@ describe('scenarios', () => {
     it('should handle a map literal', async () => {
       const results = await db.return('{ a: 1, b: true, c: "a string" } as map').run();
 
-      expectResults(results, 1, ['map'], row => {
+      expectResults(results, 1, ['map'], (row) => {
         expect(row.map).to.eql({ a: 1, b: true, c: 'a string' });
       });
     });
@@ -213,7 +218,7 @@ describe('scenarios', () => {
     it('should handle a nested array literal', async () => {
       const results = await db.return('{ a: [1, 2, 3], b: [4, 5, 6] } as map').run();
 
-      expectResults(results, 1, ['map'], row => {
+      expectResults(results, 1, ['map'], (row) => {
         expect(row.map).to.eql({ a: [1, 2, 3], b: [4, 5, 6] });
       });
     });
@@ -221,7 +226,7 @@ describe('scenarios', () => {
     it('should handle a nested map literal', async () => {
       const results = await db.return('[{ a: "name", b: true }, { c: 1, d: null }] as arr').run();
 
-      expectResults(results, 1, ['arr'], row => {
+      expectResults(results, 1, ['arr'], (row) => {
         expect(row.arr).to.eql([
           { a: 'name', b: true },
           { c: 1, d: null },

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,28 @@
+import { Connection, Credentials } from '../src';
+
+export const neo4jUrl: string = process.env.NEO4J_URL;
+export const neo4jCredentials: Credentials = {
+  username: process.env.NEO4J_USER,
+  password: process.env.NEO4J_PASS,
+};
+
+export async function waitForNeo() {
+  if (this && 'timeout' in this) {
+    this.timeout(40000);
+  }
+
+  let attempts = 0;
+  const connection = new Connection(neo4jUrl, neo4jCredentials);
+  while (attempts < 20) {
+    // Wait a short time before trying again
+    if (attempts > 0) await new Promise(res => setTimeout(res, 100));
+
+    try {
+      // Attempt a query and exit the loop if it succeeds
+      attempts += 1;
+      await connection.query().return('1').run();
+      break;
+    } catch {}
+  }
+  connection.close();
+}

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -4,6 +4,7 @@
     "src/**/*.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
+    "tests/**/*.ts",
     "*.ts"
   ],
   "exclude": []


### PR DESCRIPTION
The transformer now supports results that are arrays and map literals generated from queries like

```
db.return('range(0, 10)');
db.return('{ a: true }');
```

In addition it also supports relations and nodes that have arrays stored in their properties.

Fixes #22 
Fixes #23 