### PR TITLE
New order by constraint style

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -412,13 +412,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * // ORDER BY name DESC, occupation
    * ```
    *
-   * Valid values for directions are `DESC`, `DESCENDING`, `ASC`, `ASCENDING`.
-   * `true` and `false` are also accepted (`true` being the same as `DESC` and
-   * `false` the same as `ASC`), however they should be avoided as they are
-   * quite ambiguous. Directions always default to `ASC` as it does in cypher.
-   *
-   * *Depreciation note:*
-   * It was previously acceptable to pass an object where each key is the
+   * It is also acceptable to pass an object where each key is the
    * property and the value is a direction. Eg:
    * ```javascript
    * query.orderBy({
@@ -426,8 +420,14 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    *   occupation: 'ASC',
    * })
    * ```
-   * This has been deprecated as the iteration order of objects is not
-   * always consistent.
+   * However, the underlying iteration order is not always guaranteed and
+   * it may cause subtle bugs in your code. It is still accepted but it
+   * is recommended that you use the array syntax above.
+   *
+   * Valid values for directions are `DESC`, `DESCENDING`, `ASC`, `ASCENDING`.
+   * `true` and `false` are also accepted (`true` being the same as `DESC` and
+   * `false` the same as `ASC`), however they should be avoided as they are
+   * quite ambiguous. Directions always default to `ASC` as it does in cypher.
    *
    * @param {_.Many<string> | OrderConstraints} fields
    * @param {Direction} dir

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,7 +5,7 @@ import {
 } from './clauses';
 import { DeleteOptions } from './clauses/delete';
 import { MatchOptions } from './clauses/match';
-import { Direction, OrderConstraints } from './clauses/order-by';
+import { Direction, OrderConstraint, OrderConstraints } from './clauses/order-by';
 import { PatternCollection } from './clauses/pattern-clause';
 import { SetOptions, SetProperties } from './clauses/set';
 import { Term } from './clauses/term-list-clause';
@@ -383,43 +383,57 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * https://neo4j.com/docs/developer-manual/current/cypher/clauses/order-by}
    * to the query.
    *
-   * You can supply a single string or an array of strings to order by and the
-   * direction parameter can control which way all fields are sorted by.
+   * Pass a single string or an array of strings to order by.
    * ```javascript
    * query.orderBy([
    *   'name',
    *   'occupation',
+   * ])
+   * // ORDER BY name, occupation
+   * ```
+   *
+   * You can control the sort direction by adding a direction to each property.
+   * ```javascript
+   * query.orderBy([
+   *   ['name', 'DESC'],
+   *   'occupation', // Same as ['occupation', 'ASC']
+   * ])
+   * // ORDER BY name DESC, occupation
+   * ```
+   *
+   * The second parameter is the default search direction for all properties that
+   * don't have a direction specified. So the above query could instead be
+   * written as:
+   * ```javascript
+   * query.orderBy([
+   *   'name',
+   *   ['occupation', 'ASC']
    * ], 'DESC')
+   * // ORDER BY name DESC, occupation
    * ```
    *
-   * Results in a query of
-   * ```
-   * ORDER BY name DESC, occupation DESC
-   * ```
+   * Valid values for directions are `DESC`, `DESCENDING`, `ASC`, `ASCENDING`.
+   * `true` and `false` are also accepted (`true` being the same as `DESC` and
+   * `false` the same as `ASC`), however they should be avoided as they are
+   * quite ambiguous. Directions always default to `ASC` as it does in cypher.
    *
-   * If you would like to control the direction on each property individually,
-   * you can provide an object where each key is the property and the value is a
-   * direction. Eg:
+   * *Depreciation note:*
+   * It was previously acceptable to pass an object where each key is the
+   * property and the value is a direction. Eg:
    * ```javascript
    * query.orderBy({
    *   name: 'DESC',
    *   occupation: 'ASC',
    * })
    * ```
-   *
-   * Results in a query of
-   * ```
-   * ORDER BY name DESC, occupation
-   * ```
-   *
-   * Direction defaults to `ASC` as it does in cypher.
-   *
+   * This has been deprecated as the iteration order of objects is not
+   * always consistent.
    *
    * @param {_.Many<string> | OrderConstraints} fields
    * @param {Direction} dir
    * @returns {Q}
    */
-  orderBy(fields: Many<string> | OrderConstraints, dir?: Direction) {
+  orderBy(fields: string | (string | OrderConstraint)[] | OrderConstraints, dir?: Direction) {
     return this.continueChainClause(new OrderBy(fields, dir));
   }
 

--- a/src/clauses/order-by.spec.ts
+++ b/src/clauses/order-by.spec.ts
@@ -25,6 +25,13 @@ describe('OrderBy', () => {
     expect(query.build()).to.equal('ORDER BY node.prop DESC');
   });
 
+  it('should support null and undefined as directions', () => {
+    let query = new OrderBy('node.prop', null);
+    expect(query.build()).to.equal('ORDER BY node.prop');
+    query = new OrderBy('node.prop', undefined);
+    expect(query.build()).to.equal('ORDER BY node.prop');
+  });
+
   it('should support multiple order columns', () => {
     const query = new OrderBy(['node.prop1', 'node.prop2']);
     expect(query.build()).to.equal('ORDER BY node.prop1, node.prop2');

--- a/src/clauses/order-by.spec.ts
+++ b/src/clauses/order-by.spec.ts
@@ -43,4 +43,13 @@ describe('OrderBy', () => {
     });
     expect(query.build()).to.equal('ORDER BY node.prop1 DESC, node.prop2, node.prop3 DESC');
   });
+
+  it('should support multiple order columns with directions using the array syntax', () => {
+    const query = new OrderBy([
+      ['node.prop1', 'DESC'],
+      'node.prop2',
+      ['node.prop3', true],
+    ]);
+    expect(query.build()).to.equal('ORDER BY node.prop1 DESC, node.prop2, node.prop3 DESC');
+  });
 });

--- a/src/clauses/order-by.ts
+++ b/src/clauses/order-by.ts
@@ -25,8 +25,6 @@ export class OrderBy extends Clause {
         return { field: field[0], direction: fieldDirection };
       });
     } else {
-      // tslint:disable-next-line:max-line-length
-      console.warn('Warning: Passing constraints to OrderBy using an object is deprecated as the iteration order is not guaranteed. Use an array instead.');
       this.constraints = map(fields, (fieldDirection, field) => {
         return { field, direction: OrderBy.normalizeDirection(fieldDirection) };
       });

--- a/src/clauses/order-by.ts
+++ b/src/clauses/order-by.ts
@@ -1,7 +1,7 @@
 import { Clause } from '../clause';
 import { join, map, isString, isArray, Dictionary, trim } from 'lodash';
 
-export type Direction = boolean | 'DESC' | 'DESCENDING' | 'ASC' | 'ASCENDING';
+export type Direction = boolean | 'DESC' | 'DESCENDING' | 'ASC' | 'ASCENDING' | null | undefined;
 export type InternalDirection = 'DESC' | '';
 export type OrderConstraint = [string, Direction] | [string];
 export type InternalOrderConstraint = { field: string, direction: InternalDirection };

--- a/src/clauses/order-by.ts
+++ b/src/clauses/order-by.ts
@@ -1,33 +1,46 @@
 import { Clause } from '../clause';
-import { join, map, Many, isString, isArray, Dictionary, reduce, mapValues, assign } from 'lodash';
+import { join, map, isString, isArray, Dictionary, trim } from 'lodash';
 
 export type Direction = boolean | 'DESC' | 'DESCENDING' | 'ASC' | 'ASCENDING';
+export type InternalDirection = 'DESC' | '';
+export type OrderConstraint = [string, Direction] | [string];
+export type InternalOrderConstraint = { field: string, direction: InternalDirection };
 export type OrderConstraints = Dictionary<Direction>;
 
 export class OrderBy extends Clause {
-  constraints: Dictionary<'DESC' | ''>;
+  constraints: InternalOrderConstraint[];
 
-  constructor(fields: Many<string> | OrderConstraints, dir?: Direction) {
+  constructor(fields: string | (string | OrderConstraint)[] | OrderConstraints, dir?: Direction) {
     super();
-    const reverse = OrderBy.normalizeDirection(dir);
+    const direction = OrderBy.normalizeDirection(dir);
 
     if (isString(fields)) {
-      this.constraints = { [fields]: reverse };
+      this.constraints = [{ direction, field: fields }];
     } else if (isArray(fields)) {
-      this.constraints = reduce(fields, (obj, field) => assign(obj, { [field]: reverse }), {});
+      this.constraints = map(fields, (field): InternalOrderConstraint => {
+        if (!isArray(field)) {
+          return { field, direction };
+        }
+        const fieldDirection = field[1] ? OrderBy.normalizeDirection(field[1]) : direction;
+        return { field: field[0], direction: fieldDirection };
+      });
     } else {
-      this.constraints = mapValues(fields, OrderBy.normalizeDirection);
+      // tslint:disable-next-line:max-line-length
+      console.warn('Warning: Passing constraints to OrderBy using an object is deprecated as the iteration order is not guaranteed. Use an array instead.');
+      this.constraints = map(fields, (fieldDirection, field) => {
+        return { field, direction: OrderBy.normalizeDirection(fieldDirection) };
+      });
     }
   }
 
   build() {
-    const contraints = map(this.constraints, (dir, prop) => {
-      return prop + (dir.length > 0 ? ` ${dir}` : '');
+    const constraints = map(this.constraints, ({ field, direction }) => {
+      return trim(`${field} ${direction}`);
     });
-    return 'ORDER BY ' + join(contraints, ', ');
+    return 'ORDER BY ' + join(constraints, ', ');
   }
 
-  private static normalizeDirection(dir?: Direction): 'DESC' | '' {
+  private static normalizeDirection(dir?: Direction | string): InternalDirection {
     const isDescending = dir === 'DESC' || dir === 'DESCENDING' || dir === true;
     return isDescending ? 'DESC' : '';
   }


### PR DESCRIPTION
This pull request adds a new constraint style for OrderBy. The existing one uses an object to specify properties, however, iteration order is not always guaranteed ([see this stackoverflow question](https://stackoverflow.com/questions/30076219/does-es6-introduce-a-well-defined-order-of-enumeration-for-object-properties)). While it is probably going to be consistent for many applications, it may not be for all. The existing object style will still be accepted but it may cause subtle bugs, so be aware.