### PR TITLE
ci(docs): compile and deploy docs on ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
   - yarn validate
 after_success:
   - yarn --silent nyc report --reporter=text-lcov | sed "s|/app|$(pwd)|" | ./node_modules/.bin/coveralls
+  # Rebuild docs, only on master branch and not on pull requests
+  - [[ $TRAVIS_PULL_REQUEST = "false" && $TRAVIS_BRANCH = "master" ]] && yarn docs
 
 deploy:
   provider: script


### PR DESCRIPTION
Documentation wil now be rebuilt automatically on builds on the
master branch. It will be deployed to github when a release
occurs via the semantic-release script.