### PR TITLE
Only use `+=` operator in Set clause when value is an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
       "@semantic-release/npm",
       {
         "path": "@semantic-release/git",
-        "assets": ["package.json", "CHANGELOG.md"],
+        "assets": [
+          "package.json",
+          "CHANGELOG.md"
+        ],
         "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}\n[skip ci]\n"
       }
     ]

--- a/src/clauses/set.spec.ts
+++ b/src/clauses/set.spec.ts
@@ -59,10 +59,18 @@ describe('Set', () => {
 
   it('should merge properties when override is false', () => {
     const data = {
-      values: { node: 'value' },
+      values: { node: { name: 'complex value' } },
       variables: { node2: 'variable' },
     };
     const query = new Set(data, { override: false });
     expect(query.build()).to.equal('SET node += $node, node2 += variable');
+  });
+
+  it('should not merge plain values even when override is false', () => {
+    const data = {
+      values: { node: 'value' },
+    };
+    const query = new Set(data, { override: false });
+    expect(query.build()).to.equal('SET node = $node');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,6 +4576,12 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+rxjs@^5.5.6:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -5033,6 +5039,10 @@ supports-color@^4.0.0, supports-color@^4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
When calling `.set` or `.setValues` with `override = false`, we now check that the value is an object before applying the `+=` operator. This fixes an issue that arose when trying to call `.setValues` with primitive values for each key.

```javascript
.setValues({
  'card.title': card.title,
  'card.type': card.type,
  'card.isActive': card.isActive,
})
```

Fixes #39 