### PR TITLE
fix(Where): remove side effects from build

### DIFF
--- a/src/clauses/where.spec.ts
+++ b/src/clauses/where.spec.ts
@@ -17,5 +17,12 @@ describe('Where', () => {
         upperAge: 65,
       });
     });
+
+    it('should not have side effects on the parameters', () => {
+      const query = new Where({ age: between(18, 65) });
+      const params = query.getParams();
+      query.build();
+      expect(query.getParams()).to.deep.equal(params);
+    });
   });
 });

--- a/src/clauses/where.ts
+++ b/src/clauses/where.ts
@@ -1,28 +1,15 @@
 import { Clause } from '../clause';
 import { AnyConditions, stringCons } from './where-utils';
 
-/**
- * where({
- *    n: {
- *      name: 'james',
- *      active: eq(1),
- *      age: gt(20),
- *    }
- * });
- * where({
- *   'n.name': 'james'
- * });
- * where([
- *   { 'n.name': 'james' },
- *   { 'n.age': gt(20) },
- * ]);
- */
 export class Where extends Clause {
+  protected query: string;
+
   constructor(public conditions: AnyConditions) {
     super();
+    this.query = stringCons(this.parameterBag, this.conditions);
   }
 
   build() {
-    return 'WHERE ' + stringCons(this.parameterBag, this.conditions);
+    return 'WHERE ' + this.query;
   }
 }


### PR DESCRIPTION
Previously, calling `build()` on a where clause would add more parameters each time. This side
effect has been moved so parameters are created in the constructor.

Closes #42