### PR TITLE
 docs: correct ECMAScript versions in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ are accepted by that driver.
 
 ### Querying
 
-ES5
+ES6
 
 ```javascript
 db.matchNode('projects', 'Project')
@@ -96,7 +96,7 @@ db.matchNode('projects', 'Project')
   });
 ```
 
-ES6
+ES2017
 
 ```javascript
 const results = await db.matchNode('projects', 'Project')


### PR DESCRIPTION
Thanks for the great package! Just updating the ES versions for [`Promises`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Specifications) and [`async / await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#Specifications), easy to mix up.
