### PR TITLE
fix(Where): bind where clause parameters during build

### DIFF
--- a/src/clauses/where.spec.ts
+++ b/src/clauses/where.spec.ts
@@ -1,6 +1,8 @@
 import { Where } from './where';
 import { expect } from 'chai';
-import { between } from './where-comparators';
+import { between, lessThan } from './where-comparators';
+import { Query } from '../query';
+import { node } from './index';
 
 describe('Where', () => {
   describe('#build', () => {
@@ -18,11 +20,16 @@ describe('Where', () => {
       });
     });
 
-    it('should not have side effects on the parameters', () => {
-      const query = new Where({ age: between(18, 65) });
-      const params = query.getParams();
-      query.build();
-      expect(query.getParams()).to.deep.equal(params);
+    it('should not produce duplicate parameter names', () => {
+      const nodePattern = node('person', 'Person', { id: 1 });
+      const query = new Query().match([nodePattern])
+        .where({ id: lessThan(10) });
+      const { params, query: queryString } = query.buildQueryObject();
+      expect(queryString).to.equal(`MATCH ${nodePattern.toString()}\nWHERE id < $id2;`);
+      expect(params).to.deep.equal({
+        id: 1,
+        id2: 10,
+      });
     });
   });
 });

--- a/src/clauses/where.ts
+++ b/src/clauses/where.ts
@@ -2,14 +2,11 @@ import { Clause } from '../clause';
 import { AnyConditions, stringCons } from './where-utils';
 
 export class Where extends Clause {
-  protected query: string;
-
   constructor(public conditions: AnyConditions) {
     super();
-    this.query = stringCons(this.parameterBag, this.conditions);
   }
 
   build() {
-    return `WHERE ${this.query}`;
+    return `WHERE ${stringCons(this.parameterBag, this.conditions)}`;
   }
 }


### PR DESCRIPTION
Previously, the combined where clause was created in the constructor and then reused later. This
meant that the parameter bag wouldn't be able to create a unique name for parameters in where
comparison functions because the where clause hadn't been attached to a query yet. This commit
changes this behaviour so that the where clause is created during the build call.