### PR TITLE
fix: tell rollup to output external modules with node style paths

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default configurations.map(({ target, format }) => {
       babel({ extensions: ['.ts'] }),
     ],
     external: id => dependencies.includes(id)
-      || /\/lodash\//.test(id)
-      || /\/neo4j-driver\//.test(id),
+      || /^lodash/.test(id)
+      || /^neo4j-driver/.test(id),
   };
 });


### PR DESCRIPTION
fix #68