### PR TITLE
fix(Skip, Limit): make skip and limit only accept number amounts

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -299,7 +299,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * @param {string | number} amount
    * @returns {Q}
    */
-  limit(amount: string | number) {
+  limit(amount: number) {
     return this.continueChainClause(new Limit(amount));
   }
 
@@ -630,7 +630,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * @param {string | number} amount
    * @returns {Q}
    */
-  skip(amount: string | number) {
+  skip(amount: number) {
     return this.continueChainClause(new Skip(amount));
   }
 

--- a/src/clauses/limit.ts
+++ b/src/clauses/limit.ts
@@ -4,7 +4,7 @@ import { Parameter } from '../parameter-bag';
 export class Limit extends Clause {
   protected amountParam: Parameter;
 
-  constructor(public amount: number | string) {
+  constructor(public amount: number) {
     super();
     this.amountParam = this.addParam(amount, 'limitCount');
   }

--- a/src/clauses/skip.ts
+++ b/src/clauses/skip.ts
@@ -3,7 +3,7 @@ import { Clause } from '../clause';
 export class Skip extends Clause {
   protected amountParam;
 
-  constructor(public amount: number | string) {
+  constructor(public amount: number) {
     super();
     this.amountParam = this.addParam(amount, 'skipCount');
   }


### PR DESCRIPTION
Change the type signature for both skip and limit to prevent them from accepting a string argument.
While passing in a string would still functionally work, it is probably a bug as argument only makes
sense with a numeric value.

BREAKING CHANGE: The type of skip and limit clauses no longer accept a string. This will only effect
typescript users, there is no breaking change for javascript users.