### PR TITLE
fix(Delete): change the default behaviour of delete clause not to use DETACH DELETE

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -266,7 +266,9 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * clause to the query.
    *
    * Delete accepts a single string or an array of them and all of them are
-   * joined together with commas.
+   * joined together with commas. *Note that these strings are not escaped or
+   * passed to Neo4j using parameters, therefore you should not pass user
+   * input into this clause without escaping it first*.
    *
    * You can set `detach: true` in the options to make it a `DETACH DELETE`
    * clause.

--- a/src/clauses/delete.spec.ts
+++ b/src/clauses/delete.spec.ts
@@ -3,19 +3,24 @@ import { expect } from 'chai';
 
 describe('Delete', () => {
   describe('#build', () => {
-    it('should start with DETACH DELETE', () => {
+    it('should start with DELETE', () => {
       const query = new Delete('node');
-      expect(query.build()).to.equal('DETACH DELETE node');
+      expect(query.build()).to.equal('DELETE node');
     });
 
-    it('should start with DELETE when detach is false', () => {
-      const query = new Delete('node', { detach: false });
+    it('should start with DELETE when options are empty', () => {
+      const query = new Delete('node', {});
       expect(query.build()).to.equal('DELETE node');
+    });
+
+    it('should start with DETACH DELETE when detach is true', () => {
+      const query = new Delete('node', { detach: true });
+      expect(query.build()).to.equal('DETACH DELETE node');
     });
 
     it('should support an array of variables', () => {
       const query = new Delete(['node1', 'node2']);
-      expect(query.build()).to.equal('DETACH DELETE node1, node2');
+      expect(query.build()).to.equal('DELETE node1, node2');
     });
   });
 });

--- a/src/clauses/delete.ts
+++ b/src/clauses/delete.ts
@@ -10,7 +10,7 @@ export class Delete extends Clause {
 
   constructor(
     variables: Many<string>,
-    protected options: DeleteOptions = { detach: true },
+    protected options: DeleteOptions = { },
   ) {
     super();
     this.variables = castArray(variables);

--- a/tests/scenarios.test.ts
+++ b/tests/scenarios.test.ts
@@ -75,8 +75,8 @@ describe('scenarios', () => {
 
   before(waitForNeo);
   before(() => db = new Connection(neo4jUrl, neo4jCredentials));
-  before(() => db.matchNode('node').delete('node').run());
-  after(() => db.matchNode('node').delete('node').run());
+  before(() => db.matchNode('node').detachDelete('node').run());
+  after(() => db.matchNode('node').detachDelete('node').run());
   after(() => db.close());
 
   describe('node', () => {


### PR DESCRIPTION
… detach

Previously the `delete` clause set the detach option to true, meaning that `.delete` and
`.detachDelete` actually had the same behaviour unless you explicitly set `detach: false` in the
delete options. It makes more sense for `delete` to become a `DELETE` clause in cypher and
`detachDelete` to become a `DETACH DELETE` clause.

BREAKING CHANGE: The `.delete` method now uses `detach: false` by default meaning that it will
become a plain old `DELETE` clause in cypher. To retain the previous behaviour of becoming a `DETACH
DELETE` clause by default, use the `.detachDelete` method instead.