### PR TITLE
chore(package): update rollup to version 1.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.2",
-    "rollup": "^1.16.7",
+    "rollup": "^1.19.3",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Update to newest version of rollup. Version 1.19.0 was failing the build

Fixes #96 