### PR TITLE
Export builder, clause and clause collection

### DIFF
--- a/src/clauses/index.ts
+++ b/src/clauses/index.ts
@@ -1,4 +1,7 @@
 import { Dictionary, Many } from 'lodash';
+import { NodePattern } from './node-pattern';
+import { RelationDirection, RelationPattern } from './relation-pattern';
+import { PathLength } from '../utils';
 
 export { Create } from './create';
 export { NodePattern } from './node-pattern';
@@ -36,10 +39,6 @@ export {
   regexp,
   comparisions,
 } from './where-comparators';
-
-import { NodePattern } from './node-pattern';
-import { RelationDirection, RelationPattern } from './relation-pattern';
-import { PathLength } from '../utils';
 
 /**
  * Creates a node pattern like `(parent:Person { name: 'Gwenn' })`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 /* istanbul ignore file */
+export * from './builder';
 export * from './connection';
+export * from './clause';
+export * from './clause-collection';
 export * from './clauses';
 export * from './query';
 export * from './transformer';


### PR DESCRIPTION
Export some of the internal classes to make it easier to integrate and extend.

fix #116