### PR TITLE
Remove any-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@types/lodash": "^4.14.136",
     "@types/node": "^12.6.1",
     "any-observable": "^0.5.0",
-    "any-promise": "^1.3.0",
     "lodash": "^4.17.15",
     "neo4j-driver": "^4.0.1",
     "node-cleanup": "^2.1.2",

--- a/readme.md
+++ b/readme.md
@@ -157,11 +157,10 @@ const results = db.matchNode('project', 'Project')
 results.subscribe(row => console.log(row.project.properties.name));
 ```
 
-Under the hood, the promises and observables used by this library are constructed
-by [any-promise](https://github.com/kevinbeaty/any-promise) and 
-[any-observable](https://github.com/sindresorhus/any-observable) respectively. They
-default to using the global Promise class and the RxJS observable library, but you 
-can change that by registering another implementation before importing this module.
+Under the hood, the observables used by this library are constructed by
+[any-observable](https://github.com/sindresorhus/any-observable). They
+default to using the RxJS observable library, but you can change that by registering another 
+implementation before importing this module.
 
 ### Processing
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,4 @@
 // tslint:disable-next-line import-name
-import AnyPromise from 'any-promise';
-// tslint:disable-next-line import-name
 import Observable from 'any-observable';
 import { Observable as RxObservable } from 'rxjs';
 import { Dictionary } from 'lodash';
@@ -75,11 +73,9 @@ export class Query extends Builder<Query> {
    *
    * @returns {Promise<Dictionary<R>[]>}
    */
-  run<R = any>(): Promise<Dictionary<R>[]> {
+  async run<R = any>(): Promise<Dictionary<R>[]> {
     if (!this.connection) {
-      return AnyPromise.reject(
-        new Error('Cannot run query; no connection object available.'),
-      ) as Promise<Dictionary<R>[]>;
+      throw new Error('Cannot run query; no connection object available.');
     }
 
     return this.connection.run<R>(this);

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,11 +661,6 @@ any-observable@^0.5.0:
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.5.0.tgz#2dc6af0382b67cfd1a49e1f65e515196d4e32d38"
   integrity sha512-GnS7zaS5yBufhXeqfROuyt//AlqrN6dNHTN0Ex6vy22cIyUdeJY46rll8WLVmbV2yV2DEEl3HjspPLVLS79YZw==
 
-any-promise@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
-
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"


### PR DESCRIPTION
Removes the any-promise package. Maintaining support for it proved too much of a hassle for the
value it presented. Promises now have native support in Node and I believe there are better
solutions if you really want to use a different implementation. If you didn't use the
any-promise package then you shouldn't have to make any changes.

BREAKING CHANGE: Removes the any-promise package