### PR TITLE
Handle undefined values in Transformer

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   neo4j:
-    image: neo4j
+    image: neo4j:3.5
     ports:
       - 7474:7474
       - 7687:7687

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -64,7 +64,7 @@ export class Transformer {
 
   private isPlainValue(value: any): value is PlainValue {
     const type = typeof value;
-    return value === null || type === 'string' || type === 'boolean' || type === 'number';
+    return value == null || type === 'string' || type === 'boolean' || type === 'number';
   }
 
   private isNode(node: any): node is NeoNode {


### PR DESCRIPTION
I am getting an error when a `Point` object comes in a query result when the `z` property is `undefined`.
[See here](https://github.com/neo4j/neo4j-javascript-driver/blob/4.0/types/spatial-types.d.ts#L27)

The error happens [here](https://github.com/bboure/cypher-query-builder/blob/e05ee0641af1bcbc9cbce1557911b9ede126499a/src/transformer.ts#L88) because:
- the `Point` value is [transformed recursively as an Object](https://github.com/bboure/cypher-query-builder/blob/e05ee0641af1bcbc9cbce1557911b9ede126499a/src/transformer.ts#L60)
- `isPlain()` returns false on `undefined`
- code reached `isRelation()` but `rel` is `undefined`.
- `undefined.identity` fails.

```js
TypeError: Cannot read property 'identity' of undefined
```


This is related to #122  since Spatial objects are not properly handled either.
