### PR TITLE
Remove any observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   "dependencies": {
     "@types/lodash": "^4.14.136",
     "@types/node": "^12.6.1",
-    "any-observable": "^0.5.0",
     "lodash": "^4.17.15",
     "neo4j-driver": "^4.0.1",
     "node-cleanup": "^2.1.2",

--- a/readme.md
+++ b/readme.md
@@ -157,11 +157,6 @@ const results = db.matchNode('project', 'Project')
 results.subscribe(row => console.log(row.project.properties.name));
 ```
 
-Under the hood, the observables used by this library are constructed by
-[any-observable](https://github.com/sindresorhus/any-observable). They
-default to using the RxJS observable library, but you can change that by registering another 
-implementation before importing this module.
-
 ### Processing
 
 To extract the results, you can use ES5 array methods or a library like lodash:

--- a/src/query.spec.ts
+++ b/src/query.spec.ts
@@ -1,5 +1,3 @@
-// tslint:disable-next-line import-name
-import Observable from 'any-observable';
 import { Dictionary, each } from 'lodash';
 import { spy, stub } from 'sinon';
 import { expect } from '../test-setup';
@@ -7,6 +5,7 @@ import { mockConnection } from '../tests/connection.mock';
 import { ClauseCollection } from './clause-collection';
 import { node, NodePattern } from './clauses';
 import { Query } from './query';
+import { Observable } from 'rxjs';
 
 describe('Query', () => {
   describe('query methods', () => {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,4 @@
-// tslint:disable-next-line import-name
-import Observable from 'any-observable';
-import { Observable as RxObservable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Dictionary } from 'lodash';
 import { Connection, Observer } from './connection';
 import { Builder } from './builder';
@@ -86,7 +84,7 @@ export class Query extends Builder<Query> {
    * chainable method of a connection, then its connection was automatically
    * set.
    *
-   * Returns an observable that emits each record as it is received from the
+   * Returns an RxJS observable that emits each record as it is received from the
    * database. This is the most efficient way of working with very large
    * datasets. Each record is an object where each key is the name of a variable
    * that you specified in your return clause.
@@ -127,7 +125,7 @@ export class Query extends Builder<Query> {
    * Throws an exception if this query does not have a connection or has no
    * clauses.
    */
-  stream<R = any>(): RxObservable<Dictionary<R>> {
+  stream<R = any>(): Observable<Dictionary<R>> {
     if (!this.connection) {
       return new Observable((subscriber: Observer<Dictionary<R>>): void => {
         subscriber.error(new Error('Cannot run query; no connection object available.'));

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -1,9 +1,8 @@
-// tslint:disable-next-line import-name
-import Observable from 'any-observable';
 import { Dictionary, each } from 'lodash';
 import * as neo4j from 'neo4j-driver';
 import { Driver, Session } from 'neo4j-driver/types';
 import { AuthToken, Config } from 'neo4j-driver/types/driver';
+import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { SinonSpy, SinonStub, spy, stub } from 'sinon';
 import { Connection, Node, Query } from '../src';

--- a/typings/any-observable/index.d.ts
+++ b/typings/any-observable/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'any-observable' {
-  import { Observable } from 'rxjs';
-  export = Observable;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -656,11 +656,6 @@ ansistyles@~0.1.3:
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
   integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
 
-any-observable@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.5.0.tgz#2dc6af0382b67cfd1a49e1f65e515196d4e32d38"
-  integrity sha512-GnS7zaS5yBufhXeqfROuyt//AlqrN6dNHTN0Ex6vy22cIyUdeJY46rll8WLVmbV2yV2DEEl3HjspPLVLS79YZw==
-
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"


### PR DESCRIPTION
Removes the any-observable package. Maintaining support for it proved too much of a hassle for the value it presented. The RxJS library is quite obviously the defacto Observable library and the new Neo4j driver also uses RxJS observables.

BREAKING CHANGE: Removes the any-observable package
