### PR TITLE
Add session parameters

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -24,6 +24,7 @@ export interface Observer<T> {
 }
 
 export type DriverConstructor = typeof neo4j.driver;
+export type SessionParameters = Parameters<Driver['session']>[0]
 
 export interface FullConnectionOptions {
   driverConstructor: DriverConstructor;
@@ -120,6 +121,7 @@ export class Connection extends Builder<Query> {
     protected url: string,
     auth: Credentials | AuthToken,
     options: DriverConstructor | ConnectionOptions = neo4j.driver,
+    protected sessionParameters: SessionParameters = {}
   ) {
     super();
 
@@ -154,7 +156,7 @@ export class Connection extends Builder<Query> {
    */
   session(): Session | null {
     if (this.open) {
-      return this.driver.session();
+      return this.driver.session(this.sessionParameters);
     }
     return null;
   }


### PR DESCRIPTION
Hi there, we're testing out the library against a causal cluster with multiple database support.  
We didn't find a proper way ( let me know if we just missed something ) to pass session parameters from the basic connection instance - so we currently inherit and add an implementation similar to the one in the PR. 

Unfortunately I don't really have the time to add tests etc. for the addition and different session configuration values, but thought it would be a good addition in any case, especially for enterprise users.