### PR TITLE
fix(Package): Reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ npm_debug.log
 .idea/
 .nyc_output/
 coverage/
+docs/


### PR DESCRIPTION
Hi,

I was investigating the size of my deployed packages that were getting quite big. 
In my investigation, I found out that this package is contributing to bloating my packages.

I identified two reasons:

1) Some `@types` packages sneaked into the prod dependencies, so they were installed even on prod (`npm install --only=prod`)

2) The Docs and all sorts of unnecessary files were included in the package published to npm making it 6.57 MB unpacked.
After removing, the unpacked size is down to about 1M