### PR TITLE
feat(query): allow adding custom params

### DIFF
--- a/src/parameter-container.ts
+++ b/src/parameter-container.ts
@@ -1,5 +1,5 @@
 import { Parameter, ParameterBag } from './parameter-bag';
-import { Dictionary } from 'lodash';
+import { Dictionary, map } from 'lodash';
 
 export class ParameterContainer {
   protected parameterBag = new ParameterBag();
@@ -21,6 +21,15 @@ export class ParameterContainer {
    */
   addParam(value: any, name?: string): Parameter {
     return this.parameterBag.addParam(value, name);
+  }
+  
+  /**
+   * Adds a new parameter to the bag.
+   */
+  addParams(params: Dictionary<any>): Parameter[] {
+    return map(params, (value, name) => {
+      return this.parameterBag.addParam(value, name);
+    });
   }
 
   getParameterBag() {

--- a/src/query.spec.ts
+++ b/src/query.spec.ts
@@ -52,6 +52,28 @@ describe('Query', () => {
     });
   });
 
+  describe('parameters', () => {
+    
+    it(`should add one parameter to the parameterBag`, () => {
+      const query = new Query();
+      query.addParam('value', 'name');
+      const { params } = query.buildQueryObject();
+      expect(params).to.have.property('name', 'value');
+    });
+    
+    it(`should add several parameters to the parameterBag`, () => {
+      const query = new Query();
+      query.addParams({
+        name: 'value',
+        foo: 'bar',
+      });
+      const { params } = query.buildQueryObject();
+      expect(params).to.have.property('name', 'value');
+      expect(params).to.have.property('foo', 'bar');
+    });
+
+  });
+
   describe('proxied methods', () => {
     class TestQuery extends Query {
       getClauseCollection() {
@@ -67,6 +89,8 @@ describe('Query', () => {
       'buildQueryObject',
       'interpolate',
       'getClauses',
+      'addParam',
+      'addParams',
     ];
 
     methods.forEach((method) => {

--- a/src/query.ts
+++ b/src/query.ts
@@ -238,4 +238,27 @@ export class Query extends Builder<Query> {
     this.clauses.addClause(clause);
     return this;
   }
+
+  /**
+   * Adds a new parameter to the query
+   *
+   * @param {any} Value
+   * @param {string} Name of the parameter
+   * @returns {this}
+   */
+  addParam(value: any, name: string): this {
+    this.clauses.addParam(value, name);
+    return this;
+  }
+
+  /**
+   * Adds several parameters to the query
+   *
+   * @param params 
+   * @returns {this}
+   */
+  addParams(params: Dictionary<any>): this {
+    this.clauses.addParams(params);
+    return this;
+  }
 }


### PR DESCRIPTION
Hi,

I recently found myself needing to add custom parameters manually to a query for some advanced use cases.
I did not find any way of doing it.
This PR enables that.
