### PR TITLE
Fix handling of nested dictionaries

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -626,7 +626,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * query.return({
    *   people: [{ name: 'personName' }, 'age' ],
    * })
-   * // RETURN people.name as personName, people.age
+   * // RETURN people.name AS personName, people.age
    * ```
    * or
    * ```javascript
@@ -636,7 +636,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    *     age: 'personAge',
    *   },
    * })
-   * // RETURN people.name as personName, people.age as personAge
+   * // RETURN people.name AS personName, people.age AS personAge
    * ```
    *
    * You can also pass an array of any of the above methods.
@@ -895,7 +895,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    * query.with({
    *   people: [{ name: 'personName' }, 'age' ],
    * })
-   * // WITH people.name as personName, people.age
+   * // WITH people.name AS personName, people.age
    * ```
    * or
    * ```javascript
@@ -905,7 +905,7 @@ export abstract class Builder<Q> extends SetBlock<Q> {
    *     age: 'personAge',
    *   },
    * })
-   * // WITH people.name as personName, people.age as personAge
+   * // WITH people.name AS personName, people.age AS personAge
    * ```
    *
    * You can also pass an array of any of the above methods.

--- a/src/clauses/term-list-clause.spec.ts
+++ b/src/clauses/term-list-clause.spec.ts
@@ -27,6 +27,12 @@ describe('TermListClause', () => {
       expect(termList.getParams()).to.be.empty;
     });
 
+    it('should rename a single nested object property', () => {
+      const termList = new TermListClause({ node: { name: 'otherName', timestamp: 'created_at' } });
+      expect(termList.build()).to.equal('node.name AS otherName, node.timestamp AS created_at');
+      expect(termList.getParams()).to.be.empty;
+    });
+
     it('should be able to apply functions to properties', () => {
       const termList = new TermListClause('avg(node.count)');
       expect(termList.build()).to.equal('avg(node.count)');

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,4 @@
 import { Connection, Credentials } from '../src';
-import IHookCallbackContext = Mocha.IHookCallbackContext;
 
 export const neo4jUrl: string = process.env.NEO4J_URL as string;
 export const neo4jCredentials: Credentials = {
@@ -7,7 +6,7 @@ export const neo4jCredentials: Credentials = {
   password: process.env.NEO4J_PASS as string,
 };
 
-export async function waitForNeo(this: IHookCallbackContext) {
+export async function waitForNeo(this: Mocha.Context) {
   if (this && 'timeout' in this) {
     this.timeout(40000);
   }


### PR DESCRIPTION
The documentation described the behaviour of `with` and `return` when given a nested set of
dictionaries:
```javascript
query.with({
  people: {
    name: 'personName',
    age: 'personAge',
  },
});
// WITH people.name AS personName, people.age AS personAge
```

However the types forbade this. If using Javascript, no error was returned, however the
result was very different to the documentation. It now behaves as documentated.

If you are using Typescript this is not a breaking change as the types would have
prevented you from using the faulty behaviour.

If you as using Javascript then there is a chance that this will change the behaviour
of your code but it is unlikely and the other behaviour is a bug.

fixes #137