### PR TITLE
Add missing build step before releasing

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: 12
       - run: yarn install --frozen-lockfile
+      - run: yarn build
       - run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}


### PR DESCRIPTION
Runs `yarn build` before releasing the bundle to npm. This was
step was forgotten when migrating the build to Github Actions.

fixes #173