### PR TITLE
Add PathNamePattern class and corresponding pathName() function to allow constructing queries with named paths

### DIFF
--- a/src/clauses/index.ts
+++ b/src/clauses/index.ts
@@ -189,7 +189,7 @@ export function relation(
 }
 
 /**
- * Creates a named path pattern like `p=` for use in a MATCH clause.
+ * Creates a named path pattern like `p=` for creating named paths.
  *
  * For more details on node patterns see the cypher
  * [docs]{@link

--- a/src/clauses/index.ts
+++ b/src/clauses/index.ts
@@ -1,6 +1,7 @@
 import { Dictionary, Many } from 'lodash';
 import { NodePattern } from './node-pattern';
 import { RelationDirection, RelationPattern } from './relation-pattern';
+import { PathNamePattern } from './path-name-pattern';
 import { PathLength } from '../utils';
 
 export { Create } from './create';
@@ -10,6 +11,7 @@ export { Unwind } from './unwind';
 export { Delete } from './delete';
 export { Set } from './set';
 export { RelationPattern } from './relation-pattern';
+export { PathNamePattern } from './path-name-pattern';
 export { Match } from './match';
 export { Remove } from './remove';
 export { Return } from './return';
@@ -184,4 +186,19 @@ export function relation(
   length?: PathLength,
 ) {
   return new RelationPattern(dir, name, labels, conditions, length);
+}
+
+/**
+ * Creates a named path pattern like `p=` for use in a MATCH clause.
+ *
+ * For more details on node patterns see the cypher
+ * [docs]{@link
+ *   https://neo4j.com/docs/cypher-manual/current/clauses/match/#named-paths}
+ *
+ * @param {string} name
+ */
+export function pathName(
+    name: string,
+) {
+  return new PathNamePattern(name);
 }

--- a/src/clauses/path-name-pattern.spec.ts
+++ b/src/clauses/path-name-pattern.spec.ts
@@ -1,0 +1,11 @@
+import { PathNamePattern } from './path-name-pattern';
+import { expect } from 'chai';
+
+describe('PathNamePattern', () => {
+
+  it('should accept just a name', () => {
+    const pattern = new PathNamePattern('label');
+    expect(pattern.getLabelsString()).to.equal('');
+    expect(pattern.getNameString()).to.equal('label');
+  });
+});

--- a/src/clauses/path-name-pattern.spec.ts
+++ b/src/clauses/path-name-pattern.spec.ts
@@ -4,8 +4,9 @@ import { expect } from 'chai';
 describe('PathNamePattern', () => {
 
   it('should accept just a name', () => {
-    const pattern = new PathNamePattern('label');
+    const pattern = new PathNamePattern('p');
     expect(pattern.getLabelsString()).to.equal('');
-    expect(pattern.getNameString()).to.equal('label');
+    expect(pattern.getNameString()).to.equal('p');
+    expect(pattern.build()).to.equal('p=');
   });
 });

--- a/src/clauses/path-name-pattern.ts
+++ b/src/clauses/path-name-pattern.ts
@@ -1,0 +1,16 @@
+import { trim } from 'lodash';
+import { Pattern } from './pattern';
+
+export class PathNamePattern extends Pattern {
+  constructor(
+      name: string,
+  ) {
+    super(name);
+  }
+
+  build() {
+    let query = this.getNameString();
+    query += '=';
+    return `(${trim(query)})`;
+  }
+}

--- a/src/clauses/path-name-pattern.ts
+++ b/src/clauses/path-name-pattern.ts
@@ -11,6 +11,6 @@ export class PathNamePattern extends Pattern {
   build() {
     let query = this.getNameString();
     query += '=';
-    return `(${trim(query)})`;
+    return `${trim(query)}`;
   }
 }


### PR DESCRIPTION
Add PathNamePattern class and corresponding pathName() function to allow constructing patterns with named paths, like "MATCH p=(n)-[]-()".

(This was previously in PR #163 which I closed because our master branch got polluted with other changes.)